### PR TITLE
[Feat/#17] 모바일 Header 공통 컴포넌트 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,5 +81,6 @@
     "ts-jest": "^29.2.5",
     "ts-node": "^10.9.2",
     "typescript": "^5"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/public/assets/icon-arrow.svg
+++ b/public/assets/icon-arrow.svg
@@ -1,0 +1,3 @@
+<svg width="8" height="14" viewBox="0 0 8 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path id="Vector" d="M7 13L1 7L7 1" stroke="#6C7887" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/assets/icon-hamburger.svg
+++ b/public/assets/icon-hamburger.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="ci:hamburger-md">
+<path id="Vector" d="M5 17H19M5 12H19M5 7H19" stroke="#C2C5C7" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+</svg>

--- a/src/app/mobile/page.tsx
+++ b/src/app/mobile/page.tsx
@@ -8,7 +8,7 @@ export default function Mobile() {
         <h1>국민대학교 소프트웨어융합대학</h1>
         <p className="text-3xl font-bold">복지물품 대여 시스템</p>
       </div> */}
-      <Header title="관리자 대시보드" />
+      <Header title="관리자 대시보드" menu />
     </MobileLayout>
   );
 }

--- a/src/app/mobile/page.tsx
+++ b/src/app/mobile/page.tsx
@@ -1,12 +1,14 @@
 import MobileLayout from '@/components/mobile/layout';
+import Header from '@/components/mobile/Header';
 
 export default function Mobile() {
   return (
     <MobileLayout>
-      <div className="w-full bg-main-primary">
+      {/* <div className="w-full bg-main-primary">
         <h1>국민대학교 소프트웨어융합대학</h1>
         <p className="text-3xl font-bold">복지물품 대여 시스템</p>
-      </div>
+      </div> */}
+      <Header title="관리자 대시보드" />
     </MobileLayout>
   );
 }

--- a/src/components/mobile/Header/index.tsx
+++ b/src/components/mobile/Header/index.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+interface HeaderProps {
+  title: string;
+  menu?: boolean;
+}
+
+export default function Header({ title, menu = false }: HeaderProps) {
+  const router = useRouter();
+
+  return (
+    <section className="flex h-8 w-full items-center justify-between px-4 py-1.5">
+      <button type="button" onClick={() => router.back()}>
+        버튼
+      </button>
+      <div className="font-normal text-black-primary">{title}</div>
+      {menu ? <button>테스트</button> : <div className="h-6 w-6" />}
+    </section>
+  );
+}

--- a/src/components/mobile/Header/index.tsx
+++ b/src/components/mobile/Header/index.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
+import IconArrow from 'public/assets/icon-arrow.svg';
+import IconHambuger from 'public/assets/icon-hamburger.svg';
 
 interface HeaderProps {
   title: string;
@@ -12,11 +14,25 @@ export default function Header({ title, menu = false }: HeaderProps) {
 
   return (
     <section className="flex h-8 w-full items-center justify-between px-4 py-1.5">
-      <button type="button" onClick={() => router.back()}>
-        버튼
+      <button
+        className="h-6 w-6 items-center justify-center"
+        type="button"
+        onClick={() => router.back()}
+      >
+        <IconArrow />
       </button>
-      <div className="font-normal text-black-primary">{title}</div>
-      {menu ? <button>테스트</button> : <div className="h-6 w-6" />}
+      <div className="font-medium text-black-primary">{title}</div>
+      {menu ? (
+        <button
+          className="h-6 w-6 items-center justify-center"
+          type="button"
+          onClick={() => console.log('사이드바 오픈!')}
+        >
+          <IconHambuger />
+        </button>
+      ) : (
+        <div className="h-6 w-6" />
+      )}
     </section>
   );
 }

--- a/src/components/mobile/Header/index.tsx
+++ b/src/components/mobile/Header/index.tsx
@@ -2,7 +2,7 @@
 
 import { useRouter } from 'next/navigation';
 import IconArrow from 'public/assets/icon-arrow.svg';
-import IconHambuger from 'public/assets/icon-hamburger.svg';
+import IconHamburger from 'public/assets/icon-hamburger.svg';
 
 interface HeaderProps {
   title: string;
@@ -28,7 +28,7 @@ export default function Header({ title, menu = false }: HeaderProps) {
           type="button"
           onClick={() => console.log('사이드바 오픈!')}
         >
-          <IconHambuger />
+          <IconHamburger />
         </button>
       ) : (
         <div className="h-6 w-6" />


### PR DESCRIPTION
- Closes #17 

## 🎟️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 리팩토링

## Check List

- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [ ] 🏗️ yarn build는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요? (TODO, 주석, clg... etc.)
- [x] ✅ 컨벤션을 지켰나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요?

## ✅ Key Changes

- [x] 모바일 헤더 공통 컴포넌트 추가

## 📢 To Reviewers

일단.... next 개발도 처음이고 tailwind도 처음 써봐서 얼렁뚱땅 개발했는데 뭐든지 괜찮으니까 이거 좀 이상한데? 싶으면 코리 왕창 남겨주세요 ㅠㅠ 🥲

</br>

사용은 페이지 내에서
```
<Header title="페이지 이름" />
```
으로 사용하면 됩니다!

header를 봤을 때 우측에 햄버거바가 있는 친구가 있고 없는 친구가 있더라고요!! 기본 세팅은 false로 되어있으나 햄버거바가 필요한 페이지의 경우

사용은 페이지 내에서
```
<Header title="페이지 이름"  menu/>
```
로 이용하면 메뉴 아이콘이 생성됩니다!

</br>

현재 뒤로가기는 구현되어 있으나, 메뉴는 사이드바가 없어서 일단 콘솔로그 찍히게 두었습니다~

뷰는 mobile 페이지에서 확인할 수 있습니다!

**노트북으로 봐서 그런가 글자 크기가 분명 맞는데.. 글자가 넘 작아보이는데 한 번씩 확인해주세요!**

## 📸 스크린샷
- 햄버거바 없을 때 
![image](https://github.com/user-attachments/assets/77eebed3-26ab-45c2-a8a8-ab35025ebbcf)

- 햄버거바 있을 때
![image](https://github.com/user-attachments/assets/a3f3ac23-900f-4efa-a12f-ce6b69afd800)

