### PR TITLE
[Feat/#61] 메인에 유저 정보 띄우기 / 권한에 따른 사이드바 메뉴 변경

### DIFF
--- a/src/app/mobile/main/_components/MainHeader/index.tsx
+++ b/src/app/mobile/main/_components/MainHeader/index.tsx
@@ -7,16 +7,17 @@ import IconAlarm from 'public/assets/icons/icon-alarm.svg';
 import IconHamburger from 'public/assets/icons/icon-hamburger.svg';
 import { getNotificationCount } from '@/apis/notification';
 
-interface HeaderProps {
-  name: string;
-}
-
-export default function MainHeader({ name }: HeaderProps) {
+export default function MainHeader() {
   const router = useRouter();
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const [notificationCount, setNotificationCount] = useState<number | null>(
     null,
   );
+  const [user, setUser] = useState<{
+    name: string;
+    id: string;
+    role: string;
+  } | null>(null);
 
   useEffect(() => {
     const fetchNotificationCount = async () => {
@@ -31,11 +32,18 @@ export default function MainHeader({ name }: HeaderProps) {
     fetchNotificationCount();
   }, []);
 
+  useEffect(() => {
+    const storedUser = localStorage.getItem('user');
+    if (storedUser) {
+      setUser(JSON.parse(storedUser));
+    }
+  }, []);
+
   return (
     <>
       <section className="fixed top-0 z-10 flex h-10 w-full max-w-md items-center justify-between bg-[#F3F4F6] px-4 py-1.5">
         <div className="text-heading-3_D font-semibold text-black-primary">
-          {name}님
+          {user?.name}님
         </div>
         <div className="flex gap-[7px]">
           <button
@@ -60,7 +68,11 @@ export default function MainHeader({ name }: HeaderProps) {
         </div>
       </section>
 
-      <Sidebar isOpen={isSidebarOpen} onClose={() => setIsSidebarOpen(false)} />
+      <Sidebar
+        isOpen={isSidebarOpen}
+        onClose={() => setIsSidebarOpen(false)}
+        role={user?.role}
+      />
     </>
   );
 }

--- a/src/app/mobile/main/page.tsx
+++ b/src/app/mobile/main/page.tsx
@@ -66,7 +66,7 @@ export default function MobileMain() {
 
   return (
     <MobileLayout>
-      <MainHeader name="황현진" />
+      <MainHeader />
       <div className="mt-10 flex flex-col gap-[50px] px-4 pt-4">
         <Carousel
           images={imageUrls}

--- a/src/components/mobile/Header/index.tsx
+++ b/src/components/mobile/Header/index.tsx
@@ -2,7 +2,7 @@
 
 import { useRouter } from 'next/navigation';
 import Sidebar from '@/components/mobile/SidebarMenu/index';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import IconArrow from 'public/assets/icons/icon-arrow.svg';
 import IconHamburger from 'public/assets/icons/icon-hamburger.svg';
 
@@ -14,6 +14,18 @@ interface HeaderProps {
 export default function Header({ title, menu = false }: HeaderProps) {
   const router = useRouter();
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+  const [user, setUser] = useState<{
+    name: string;
+    id: string;
+    role: string;
+  } | null>(null);
+
+  useEffect(() => {
+    const storedUser = localStorage.getItem('user');
+    if (storedUser) {
+      setUser(JSON.parse(storedUser));
+    }
+  }, []);
 
   return (
     <>
@@ -39,7 +51,11 @@ export default function Header({ title, menu = false }: HeaderProps) {
         )}
       </section>
 
-      <Sidebar isOpen={isSidebarOpen} onClose={() => setIsSidebarOpen(false)} />
+      <Sidebar
+        isOpen={isSidebarOpen}
+        onClose={() => setIsSidebarOpen(false)}
+        role={user?.role}
+      />
     </>
   );
 }

--- a/src/components/mobile/SidebarMenu/index.tsx
+++ b/src/components/mobile/SidebarMenu/index.tsx
@@ -11,7 +11,7 @@ import IconLogout from 'public/assets/icons/side-menu/logout.svg';
 interface SidebarProps {
   isOpen: boolean;
   onClose: () => void;
-  isAdmin?: boolean;
+  role?: string;
 }
 
 const menuItems = [
@@ -42,7 +42,7 @@ const logoutItem = {
 export default function Sidebar({
   isOpen,
   onClose,
-  isAdmin = true, // 여기서 관리자 여부 설정
+  role = 'USER', // 여기서 관리자 여부 설정
 }: SidebarProps) {
   return (
     <>
@@ -90,7 +90,7 @@ export default function Sidebar({
           <div className="my-5 border-t border-gray-border" />
 
           {/* 관리자 메뉴 */}
-          {isAdmin && (
+          {role === 'ADMIN' && (
             <>
               <ul className="text-body-2-normal_semi font-semibold text-black-primary">
                 {adminItems.map(({ icon: Icon, label, href }) => (


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

## 📌 관련 이슈번호

<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

- Closes #61 

## 🎟️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 리팩토링

## Check List

- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [ ] 🏗️ yarn build는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요? (TODO, 주석, clg... etc.)
- [x] ✅ 컨벤션을 지켰나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요?

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 작업 내용
- 로컬스토리지에 있는 유저 정보를 가져와서 메인에 띄웠습니다.
- 유저의 권한에 따라 보이는 사이드바 메뉴가 다르도록 수정하였습니다.

## 📢 To Reviewers
- 추후에 zustand를 사용하는 코드로 리팩토링 하겠습니다.

## 📸 스크린샷

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->

## 🔗 참고 자료

<!-- 참고 레퍼런스를 첨부해주세요.  -->
