### PR TITLE
[Feat/#57] 대시보드 API 연결

### DIFF
--- a/src/app/mobile/admin/dashboard/_components/DashboardItem.tsx
+++ b/src/app/mobile/admin/dashboard/_components/DashboardItem.tsx
@@ -1,14 +1,6 @@
 import Image from 'next/image';
 import convertTime from '@/utils/convertTime';
-
-interface DashboardItemProps {
-  itemName: string;
-  imageUrl: string;
-  renterName: string;
-  studentId: number;
-  status: string;
-  applicatedAt: string;
-}
+import { DashboardProps } from '@/types/dashboardType';
 
 export default function DashboardItem({
   itemName,
@@ -17,10 +9,21 @@ export default function DashboardItem({
   studentId,
   status,
   applicatedAt,
-}: DashboardItemProps) {
-  const RentalBtnText: Record<string, string> = {
-    PENDING: '대여',
-    RETURN_PENDING: '반납',
+  handleApproveBtnClick,
+  handleCancelBtnClick,
+}: DashboardProps) {
+  const RentalApproveBtnText: Record<string, string> = {
+    PENDING: '대여 승인',
+    RETURN_PENDING: '반납 승인',
+    RETURN_CONFIRMED: '반납 완료',
+  };
+
+  const handleApproveBtn = () => {
+    handleApproveBtnClick();
+  };
+
+  const handleCancelBtn = () => {
+    handleCancelBtnClick();
   };
 
   const applicatedTime = convertTime(applicatedAt);
@@ -54,20 +57,20 @@ export default function DashboardItem({
       </section>
 
       <section className="flex gap-2.5 text-sm font-semibold">
-        {/* TODO : API 보고 onClick 연결하기 */}
         <button
           type="button"
-          onClick={() => console.log('수락!')}
+          onClick={handleApproveBtn}
           className="text-return-blue"
         >
-          {RentalBtnText[status]} 승인
+          {RentalApproveBtnText[status]}
         </button>
         <button
           type="button"
-          onClick={() => console.log('취소!')}
+          onClick={handleCancelBtn}
           className="text-return-red"
         >
-          {RentalBtnText[status]} 취소
+          {/* PENDING일 때만 가능하도록 */}
+          대여 취소
         </button>
       </section>
     </section>

--- a/src/app/mobile/admin/dashboard/_components/DashboardItem.tsx
+++ b/src/app/mobile/admin/dashboard/_components/DashboardItem.tsx
@@ -32,9 +32,9 @@ export default function DashboardItem({
     <section className="flex w-full items-center justify-between px-5 py-4">
       <section className="flex items-center gap-4">
         <section className="flex h-10 w-10 items-center justify-center rounded-full bg-gray-tertiary p-2.5">
-          {imageUrl && (
-            <Image src={imageUrl} width={24} height={24} alt="물품 아이콘" />
-          )}
+          {/* {imageUrl && ( */}
+          <Image src={imageUrl} width={24} height={24} alt="물품 아이콘" />
+          {/* )} */}
         </section>
 
         <section className="flex flex-col gap-2">
@@ -59,6 +59,17 @@ export default function DashboardItem({
       </section>
 
       <section className="flex gap-2.5 text-sm font-semibold">
+        {status === 'PENDING' ? (
+          <button
+            type="button"
+            onClick={handleCancelBtn}
+            className="w-14 text-return-red"
+          >
+            대여 취소
+          </button>
+        ) : (
+          <div className="w-14" />
+        )}
         <button
           type="button"
           onClick={handleApproveBtn}
@@ -66,15 +77,6 @@ export default function DashboardItem({
         >
           {RentalApproveBtnText[status]}
         </button>
-        {status === 'PENDING' && (
-          <button
-            type="button"
-            onClick={handleCancelBtn}
-            className="text-return-red"
-          >
-            대여 취소
-          </button>
-        )}
       </section>
     </section>
   );

--- a/src/app/mobile/admin/dashboard/_components/DashboardItem.tsx
+++ b/src/app/mobile/admin/dashboard/_components/DashboardItem.tsx
@@ -4,7 +4,7 @@ import { DashboardProps } from '@/types/dashboardType';
 
 export default function DashboardItem({
   itemName,
-  imageUrl,
+  itemImageUrl,
   renterName,
   studentId,
   status,
@@ -32,9 +32,14 @@ export default function DashboardItem({
     <section className="flex w-full items-center justify-between px-5 py-4">
       <section className="flex items-center gap-4">
         <section className="flex h-10 w-10 items-center justify-center rounded-full bg-gray-tertiary p-2.5">
-          {/* {imageUrl && ( */}
-          <Image src={imageUrl} width={24} height={24} alt="물품 아이콘" />
-          {/* )} */}
+          {itemImageUrl && (
+            <Image
+              src={itemImageUrl}
+              width={24}
+              height={24}
+              alt="물품 아이콘"
+            />
+          )}
         </section>
 
         <section className="flex flex-col gap-2">

--- a/src/app/mobile/admin/dashboard/_components/DashboardItem.tsx
+++ b/src/app/mobile/admin/dashboard/_components/DashboardItem.tsx
@@ -32,7 +32,9 @@ export default function DashboardItem({
     <section className="flex w-full items-center justify-between px-5 py-4">
       <section className="flex items-center gap-4">
         <section className="flex h-10 w-10 items-center justify-center rounded-full bg-gray-tertiary p-2.5">
-          <Image src={imageUrl} width={24} height={24} alt="물품 아이콘" />
+          {imageUrl && (
+            <Image src={imageUrl} width={24} height={24} alt="물품 아이콘" />
+          )}
         </section>
 
         <section className="flex flex-col gap-2">
@@ -64,14 +66,15 @@ export default function DashboardItem({
         >
           {RentalApproveBtnText[status]}
         </button>
-        <button
-          type="button"
-          onClick={handleCancelBtn}
-          className="text-return-red"
-        >
-          {/* PENDING일 때만 가능하도록 */}
-          대여 취소
-        </button>
+        {status === 'PENDING' && (
+          <button
+            type="button"
+            onClick={handleCancelBtn}
+            className="text-return-red"
+          >
+            대여 취소
+          </button>
+        )}
       </section>
     </section>
   );

--- a/src/app/mobile/admin/dashboard/page.tsx
+++ b/src/app/mobile/admin/dashboard/page.tsx
@@ -121,7 +121,7 @@ export default function Dashboard() {
           <DashboardItem
             key={item.rentalHistoryId}
             itemName={item.itemName}
-            imageUrl={item.imageUrl}
+            itemImageUrl={item.itemImageUrl}
             renterName={item.renterName}
             studentId={item.studentId}
             status={item.status}

--- a/src/services/dashboard.ts
+++ b/src/services/dashboard.ts
@@ -1,8 +1,13 @@
 import PrivateAxiosInstance from './privateAxiosInstance';
 
-const adminDashboardGet = async () => {
+const adminDashboardGet = async (rentalStatus?: string) => {
   try {
-    const response = await PrivateAxiosInstance.get('/admin/rentals/dashboard');
+    const response = await PrivateAxiosInstance.get(
+      '/admin/rentals/dashboard',
+      {
+        params: { rentalStatus },
+      },
+    );
     return response.data;
   } catch (error) {
     return [];

--- a/src/services/dashboard.ts
+++ b/src/services/dashboard.ts
@@ -1,0 +1,32 @@
+import PrivateAxiosInstance from './privateAxiosInstance';
+
+const adminDashboardGet = async () => {
+  try {
+    const response = await PrivateAxiosInstance.get('/admin/rentals/dashboard');
+    return response.data;
+  } catch (error) {
+    return [];
+  }
+};
+
+interface AdminRentalPatchProps {
+  rentalHistoryId: number;
+  rentalStatus: string;
+}
+
+const adminRentalPatch = async ({
+  rentalHistoryId,
+  rentalStatus,
+}: AdminRentalPatchProps) => {
+  try {
+    const response = await PrivateAxiosInstance.patch(
+      `/admin/rentals/${rentalHistoryId}`,
+      { rentalStatus },
+    );
+    return response.data;
+  } catch (error) {
+    return [];
+  }
+};
+
+export { adminDashboardGet, adminRentalPatch };

--- a/src/types/dashboardType.ts
+++ b/src/types/dashboardType.ts
@@ -1,0 +1,11 @@
+export interface DashboardProps {
+  rentalHistoryId?: number;
+  itemName: string;
+  imageUrl: string;
+  renterName: string;
+  studentId: string;
+  status: string;
+  applicatedAt: string;
+  handleApproveBtnClick: () => void;
+  handleCancelBtnClick: () => void;
+}

--- a/src/types/dashboardType.ts
+++ b/src/types/dashboardType.ts
@@ -1,7 +1,7 @@
 export interface DashboardProps {
   rentalHistoryId?: number;
   itemName: string;
-  imageUrl: string;
+  itemImageUrl: string;
   renterName: string;
   studentId: string;
   status: string;


### PR DESCRIPTION
## 📌 관련 이슈번호

- Closes #57 

## 🎟️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 리팩토링

## Check List

- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [x] 🏗️ yarn build는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요? (TODO, 주석, clg... etc.)
- [x] ✅ 컨벤션을 지켰나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요?

## ✅ Key Changes

1. 대시보드 GET API 연결
2. 대시보드 PATCH API 연결

## 📢 To Reviewers

- 수민 오빠랑 얘기해본 결과... 반납은 취소가 없는 게 더 좋을 것 같다고 결정서 대여만 취소 버튼을 넣고 반납은 완료/승인만 넣었습니다!
- 원래 반납이 반납 승인만 있었는데 생각해보니까 관리자가 반납을 완료하는 로직이 없어서 대시보드에 반납 완료 처리까지 함께 넣었습니다.
-> 그래서 반납의 경우 반납 승인 버튼이 우측 정렬이 되었는데... 다른 승인 버튼들과 간격을 맞추는 게 좋을까요?? 근데 그렇게 하면 오른쪽에 애매하게 공간이 남는 것 같아서... 다들 의견 남겨주세요
- 지금 svg가 전달이 안 오는데... aws에서 지워져서 안 오는 건지 뭔가 문제가 있는 건지 판단이 안 서서 일단 머지하고 수민 오빠한테 서버 svg 수정해달라고 요청한 후에 다시 수정해볼게요!

## 📸 스크린샷

![image](https://github.com/user-attachments/assets/8e23cc3f-7e1f-49ce-8f05-29fe365f8695)
