### PR TITLE
[Feat/#71] 대시보드 내 대여 완료 기능 구현

### DIFF
--- a/src/app/mobile/admin/dashboard/_components/DashboardItem.tsx
+++ b/src/app/mobile/admin/dashboard/_components/DashboardItem.tsx
@@ -14,6 +14,7 @@ export default function DashboardItem({
 }: DashboardProps) {
   const RentalApproveBtnText: Record<string, string> = {
     PENDING: '대여 승인',
+    CONFIRMED: '대여 완료',
     RETURN_PENDING: '반납 승인',
     RETURN_CONFIRMED: '반납 완료',
   };

--- a/src/app/mobile/admin/dashboard/page.tsx
+++ b/src/app/mobile/admin/dashboard/page.tsx
@@ -9,6 +9,7 @@ import IconArrow from 'public/assets/icons/icon-arrow.svg';
 import { cn } from '@/lib/utils';
 import { adminDashboardGet, adminRentalPatch } from '@/services/dashboard';
 import { DashboardProps } from '@/types/dashboardType';
+import { RentalStatusText } from '@/constants/rentalStatus';
 import DashboardItem from './_components/DashboardItem';
 
 type DashboardType = DashboardProps;
@@ -17,7 +18,7 @@ interface RentalRequestProps {
   rentalHistoryId: number;
   itemName: string;
   renterName: string;
-  status?: string;
+  status: string;
 }
 
 export default function Dashboard() {
@@ -83,7 +84,9 @@ export default function Dashboard() {
     const data = { rentalHistoryId, rentalStatus: newStatus };
     await adminRentalPatch(data);
 
-    alert(`${renterName} 님의 ${itemName} 요청이 처리되었습니다.`);
+    alert(
+      `${renterName} 님의 ${itemName} ${RentalStatusText[status]} 요청이 처리되었습니다.`,
+    );
 
     // TODO : 현재 임시로 상태로 관리 -> 추후 refetch로 변경
     setRefreshTrigger((prev) => !prev);
@@ -93,11 +96,14 @@ export default function Dashboard() {
     rentalHistoryId,
     itemName,
     renterName,
+    status,
   }: RentalRequestProps) => {
     const data = { rentalHistoryId, rentalStatus: 'CANCEL' };
     await adminRentalPatch(data);
 
-    alert(`${renterName} 님의 ${itemName} 요청이 처리되었습니다.`);
+    alert(
+      `${renterName} 님의 ${itemName} ${RentalStatusText[status]} 요청이 처리되었습니다.`,
+    );
 
     // TODO : 현재 임시로 상태로 관리 -> 추후 refetch로 변경
     setRefreshTrigger((prev) => !prev);
@@ -156,6 +162,7 @@ export default function Dashboard() {
                   rentalHistoryId: item.rentalHistoryId,
                   itemName: item.itemName,
                   renterName: item.renterName,
+                  status: item.status,
                 });
               }
             }}

--- a/src/app/mobile/admin/dashboard/page.tsx
+++ b/src/app/mobile/admin/dashboard/page.tsx
@@ -15,7 +15,9 @@ type DashboardType = DashboardProps;
 
 interface RentalRequestProps {
   rentalHistoryId: number;
-  status: string;
+  itemName: string;
+  renterName: string;
+  status?: string;
 }
 
 export default function Dashboard() {
@@ -65,25 +67,37 @@ export default function Dashboard() {
 
   const handleApproveBtnClick = async ({
     rentalHistoryId,
+    itemName,
+    renterName,
     status,
   }: RentalRequestProps) => {
     const statusMap: Record<string, string> = {
       PENDING: 'CONFIRMED',
+      CONFIRMED: 'RENTAL',
       RETURN_PENDING: 'RETURN_CONFIRMED',
       RETURN_CONFIRMED: 'RETURNED',
     };
 
-    const newStatus = statusMap[status] ?? status;
+    const newStatus = statusMap[status!] ?? status;
 
     const data = { rentalHistoryId, rentalStatus: newStatus };
     await adminRentalPatch(data);
+
+    alert(`${renterName} 님의 ${itemName} 요청이 처리되었습니다.`);
+
     // TODO : 현재 임시로 상태로 관리 -> 추후 refetch로 변경
     setRefreshTrigger((prev) => !prev);
   };
 
-  const handleCancelBtnClick = async (rentalHistoryId: number) => {
+  const handleCancelBtnClick = async ({
+    rentalHistoryId,
+    itemName,
+    renterName,
+  }: RentalRequestProps) => {
     const data = { rentalHistoryId, rentalStatus: 'CANCEL' };
     await adminRentalPatch(data);
+
+    alert(`${renterName} 님의 ${itemName} 요청이 처리되었습니다.`);
 
     // TODO : 현재 임시로 상태로 관리 -> 추후 refetch로 변경
     setRefreshTrigger((prev) => !prev);
@@ -130,13 +144,19 @@ export default function Dashboard() {
               if (item.rentalHistoryId !== undefined) {
                 handleApproveBtnClick({
                   rentalHistoryId: item.rentalHistoryId,
+                  itemName: item.itemName,
+                  renterName: item.renterName,
                   status: item.status,
                 });
               }
             }}
             handleCancelBtnClick={() => {
               if (item.rentalHistoryId !== undefined) {
-                handleCancelBtnClick(item.rentalHistoryId);
+                handleCancelBtnClick({
+                  rentalHistoryId: item.rentalHistoryId,
+                  itemName: item.itemName,
+                  renterName: item.renterName,
+                });
               }
             }}
           />

--- a/src/app/mobile/admin/dashboard/page.tsx
+++ b/src/app/mobile/admin/dashboard/page.tsx
@@ -22,13 +22,6 @@ interface RentalRequestProps {
 }
 
 export default function Dashboard() {
-  const RentalFilterText: Record<string, string> = {
-    ALL: '전체',
-    PENDING: '대여 신청',
-    RETURN_PENDING: '반납 신청',
-    RETURN_CONFIRMED: '반납 대기',
-  };
-
   const [dashboardDetail, setDashboardDetail] = useState<DashboardType[]>([]);
   const [filter, setFilter] = useState('ALL');
   const [refreshTrigger, setRefreshTrigger] = useState(false);
@@ -50,9 +43,10 @@ export default function Dashboard() {
 
   const dropdownActions = [
     { title: '전체', func: () => handleFilter('ALL') },
-    { title: '대여 신청', func: () => handleFilter('PENDING') },
-    { title: '반납 신청', func: () => handleFilter('RETURN_PENDING') },
-    { title: '반납 대기', func: () => handleFilter('RETURN_CONFIRMED') },
+    { title: '대여 요청', func: () => handleFilter('PENDING') },
+    { title: '대여 승인', func: () => handleFilter('CONFIRMED') },
+    { title: '반납 요청', func: () => handleFilter('RETURN_PENDING') },
+    { title: '반납 승인', func: () => handleFilter('RETURN_CONFIRMED') },
   ];
 
   useEffect(() => {
@@ -123,7 +117,7 @@ export default function Dashboard() {
           className={`flex items-center gap-2.5 ${isDropdownVisible && 'pointer-events-none'}`}
         >
           <div className="flex text-sm font-semibold">
-            {RentalFilterText[filter]}
+            {filter === 'ALL' ? '전체' : RentalStatusText[filter]}
           </div>
           <IconArrow
             className={

--- a/src/constants/rentalStatus.ts
+++ b/src/constants/rentalStatus.ts
@@ -1,0 +1,25 @@
+export const RENTAL_STATUS = {
+  PENDING: 'PENDING',
+  CANCEL: 'CANCEL',
+  REJECTED: 'REJECTED',
+  CONFIRMED: 'CONFIRMED',
+  RENTAL: 'RENTAL',
+  RETURN_PENDING: 'RETURN_PENDING',
+  RETURN_CONFIRMED: 'RETURN_CONFIRMED',
+  RETURNED: 'RETURNED',
+};
+
+export type RentalStatus = (typeof RENTAL_STATUS)[keyof typeof RENTAL_STATUS];
+
+export const RentalStatusText: Record<RentalStatus, string> = {
+  [RENTAL_STATUS.PENDING]: '승인 대기 중',
+  [RENTAL_STATUS.CANCEL]: '대기 취소',
+  [RENTAL_STATUS.REJECTED]: '대여 신청 반려',
+  [RENTAL_STATUS.CONFIRMED]: '승인 완료',
+  [RENTAL_STATUS.RENTAL]: '대여 중',
+  [RENTAL_STATUS.RETURN_PENDING]: '반납 대기 중',
+  [RENTAL_STATUS.RETURN_CONFIRMED]: '반납 승인',
+  [RENTAL_STATUS.RETURNED]: '반납 완료',
+} as const;
+
+export type RentalStatusTypes = keyof typeof RentalStatusText;

--- a/src/constants/rentalStatus.ts
+++ b/src/constants/rentalStatus.ts
@@ -12,12 +12,12 @@ export const RENTAL_STATUS = {
 export type RentalStatus = (typeof RENTAL_STATUS)[keyof typeof RENTAL_STATUS];
 
 export const RentalStatusText: Record<RentalStatus, string> = {
-  [RENTAL_STATUS.PENDING]: '승인 대기 중',
+  [RENTAL_STATUS.PENDING]: '대여 요청',
   [RENTAL_STATUS.CANCEL]: '대기 취소',
-  [RENTAL_STATUS.REJECTED]: '대여 신청 반려',
-  [RENTAL_STATUS.CONFIRMED]: '승인 완료',
+  [RENTAL_STATUS.REJECTED]: '대여 반려',
+  [RENTAL_STATUS.CONFIRMED]: '대여 승인',
   [RENTAL_STATUS.RENTAL]: '대여 중',
-  [RENTAL_STATUS.RETURN_PENDING]: '반납 대기 중',
+  [RENTAL_STATUS.RETURN_PENDING]: '반납 요청',
   [RENTAL_STATUS.RETURN_CONFIRMED]: '반납 승인',
   [RENTAL_STATUS.RETURNED]: '반납 완료',
 } as const;


### PR DESCRIPTION
## 📌 관련 이슈번호

- Closes #71 

## 🎟️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 리팩토링

## Check List

- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [x] 🏗️ yarn build는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요? (TODO, 주석, clg... etc.)
- [x] ✅ 컨벤션을 지켰나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요?

## ✅ Key Changes

- 대시보드 내 대여 승인 -> 대여 완료를 처리하는 로직이 없어서 추가했습니다.

## 📢 To Reviewers

- 지금 버튼 누르면 바로 완료 눌리는 게 위험할 수도 있겠다 싶어서 모달 alert 로직을 추가하려고 했는데... 제 졸림 이슈로 현진 언니 코드를 이해하다 말아서 리팩토링 때 추가하거나 내일 일어나서 추가하도록 할게요! 수민 오빠가 판단했을 때 급하다... (꼭 필요한 기능이다) 싶으면 내일 바로 처리하겠습니다

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/ae60743f-31a9-4756-8bb2-c7075f8112b1)
