### PR TITLE
feat: 관리자 데스크탑 로그인 페이지 구현

### DIFF
--- a/src/app/callback/page.tsx
+++ b/src/app/callback/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, Suspense } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
-import { decode } from 'js-base64';
+import { handleLoginSuccess } from '@/utils/loginHandler';
 
 function CallbackContent() {
   const searchParams = useSearchParams();
@@ -27,20 +27,7 @@ function CallbackContent() {
         break;
       case 'SUCCESS':
       default:
-        if (accessToken) {
-          const payload = accessToken.split('.')[1] || '';
-          const decodedPayload = decode(payload);
-          const payloadObject = JSON.parse(decodedPayload);
-
-          const tokenRole = payloadObject.role;
-          const tokenName = payloadObject.name;
-          const tokenId = payloadObject.sub;
-
-          const userInfo = { name: tokenName, id: tokenId, role: tokenRole };
-
-          localStorage.setItem('token', accessToken);
-          localStorage.setItem('user', JSON.stringify(userInfo));
-        }
+        handleLoginSuccess(accessToken);
         router.replace('/mobile/main');
         break;
     }

--- a/src/app/desktop/login/page.tsx
+++ b/src/app/desktop/login/page.tsx
@@ -12,19 +12,19 @@ export default function Login() {
   const studentIdRef = useRef<HTMLInputElement | null>(null);
   const passwordRef = useRef<HTMLInputElement | null>(null);
 
-  const validateLoginForm = () => {
-    if (!studentIdRef.current || !studentIdRef.current.value) {
+  const validateLoginForm = (studentId: string, password: string) => {
+    if (!studentId) {
       alert('학번을 입력해 주세요!');
       return false;
     }
 
-    if (!passwordRef.current || !passwordRef.current.value) {
+    if (!password) {
       alert('비밀번호를 입력해 주세요!');
       return false;
     }
 
     const idRegex = /^\d{8}$/;
-    if (!idRegex.test(studentIdRef.current.value)) {
+    if (!idRegex.test(studentId)) {
       alert('학번은 숫자 8자리여야 합니다.');
       return false;
     }
@@ -33,10 +33,10 @@ export default function Login() {
   };
 
   const handleAdminLogin = async () => {
-    if (!validateLoginForm()) return;
+    const studentId = studentIdRef?.current?.value || '';
+    const password = passwordRef?.current?.value || '';
 
-    const studentId = studentIdRef?.current?.value as string;
-    const password = passwordRef?.current?.value as string;
+    if (!validateLoginForm(studentId, password)) return;
 
     try {
       const data = await postAdminLogin({

--- a/src/app/desktop/login/page.tsx
+++ b/src/app/desktop/login/page.tsx
@@ -1,10 +1,101 @@
+'use client';
+
+import ImageLoginLogo from 'public/assets/images/image-login-logo.svg';
+import { useRef } from 'react';
+import axios from 'axios';
+import { postAdminLogin } from '@/services/admins';
+import { handleLoginSuccess } from '@/utils/loginHandler';
+import { useRouter } from 'next/navigation';
+
 export default function Login() {
+  const router = useRouter();
+  const studentIdRef = useRef<HTMLInputElement | null>(null);
+  const passwordRef = useRef<HTMLInputElement | null>(null);
+
+  const validateLoginForm = () => {
+    if (!studentIdRef.current || !studentIdRef.current.value) {
+      alert('학번을 입력해 주세요!');
+      return false;
+    }
+
+    if (!passwordRef.current || !passwordRef.current.value) {
+      alert('비밀번호를 입력해 주세요!');
+      return false;
+    }
+
+    const idRegex = /^\d{8}$/;
+    if (!idRegex.test(studentIdRef.current.value)) {
+      alert('학번은 숫자 8자리여야 합니다.');
+      return false;
+    }
+
+    return true;
+  };
+
+  const handleAdminLogin = async () => {
+    if (!validateLoginForm()) return;
+
+    const studentId = studentIdRef?.current?.value as string;
+    const password = passwordRef?.current?.value as string;
+
+    try {
+      const data = await postAdminLogin({
+        studentId,
+        password,
+      });
+
+      handleLoginSuccess(data.accessToken);
+      router.push('/desktop/rental-history');
+    } catch (error) {
+      if (axios.isAxiosError(error)) {
+        const errorResponse = error.response?.data;
+
+        if (!errorResponse) {
+          alert('관리자 로그인 중 오류가 발생했습니다!');
+          return;
+        }
+
+        alert(errorResponse.message);
+      }
+    }
+  };
+
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center gap-16 p-8 pb-20">
-      <div className="text-center">
-        <h1>국민대학교 소프트웨어융합대학</h1>
-        <p className="text-3xl font-bold">복지물품 대여 시스템</p>
-      </div>
+    <div className="flex min-h-screen flex-row items-center justify-center gap-80 p-8 pb-20">
+      <section>
+        <ImageLoginLogo />
+      </section>
+      <section className="flex w-[512px] flex-col items-center justify-center">
+        <div className="flex w-[300px] flex-col items-center justify-center gap-11 text-center">
+          <div>
+            <h1>국민대학교 소프트웨어융합대학</h1>
+            <p className="text-3xl font-bold">복지물품 대여 시스템</p>
+          </div>
+          <div className="flex w-full flex-col items-center justify-center gap-5">
+            <input
+              className="w-full border-b-2 border-gray-secondary pb-1 pl-1 pt-1 text-start text-body-1-normal_medi placeholder-gray-secondary placeholder:text-body-1-normal_medi focus:outline-none"
+              type="text"
+              placeholder="학번"
+              ref={studentIdRef}
+            />
+            <input
+              className="w-full border-b-2 border-gray-secondary pb-1 pl-1 pt-1 text-start text-body-1-normal_medi placeholder-gray-secondary placeholder:text-body-1-normal_medi focus:outline-none"
+              type="password"
+              placeholder="비밀번호"
+              ref={passwordRef}
+            />
+          </div>
+          <div className="w-full items-center justify-center">
+            <button
+              className="w-full rounded bg-on-kookmin pb-2 pt-2 text-center text-body-1-normal_medi text-white"
+              type="button"
+              onClick={handleAdminLogin}
+            >
+              로그인
+            </button>
+          </div>
+        </div>
+      </section>
     </div>
   );
 }

--- a/src/services/admins.ts
+++ b/src/services/admins.ts
@@ -1,3 +1,4 @@
+import PublicAxiosInstance from '@/services/publicAxiosInstance';
 import PrivateAxiosInstance from './privateAxiosInstance';
 
 export const getAdmins = async () => {
@@ -21,5 +22,22 @@ export const deleteAdmins = async (memberIds: number[]) => {
   const response = await PrivateAxiosInstance.delete('/admin/members/admins', {
     data: { memberIds },
   });
+  return response.data;
+};
+
+interface AdminLoginProps {
+  studentId: string;
+  password: string;
+}
+
+export const postAdminLogin = async ({
+  studentId,
+  password,
+}: AdminLoginProps) => {
+  const response = await PublicAxiosInstance.post('/auth/admin-login', {
+    studentId,
+    password,
+  });
+
   return response.data;
 };

--- a/src/utils/loginHandler.ts
+++ b/src/utils/loginHandler.ts
@@ -1,0 +1,18 @@
+import { decode } from 'js-base64';
+
+export const handleLoginSuccess = (accessToken: string | null) => {
+  if (accessToken) {
+    const payload = accessToken.split('.')[1] || '';
+    const decodedPayload = decode(payload);
+    const payloadObject = JSON.parse(decodedPayload);
+
+    const tokenRole = payloadObject.role;
+    const tokenName = payloadObject.name;
+    const tokenId = payloadObject.sub;
+
+    const userInfo = { name: tokenName, id: tokenId, role: tokenRole };
+
+    localStorage.setItem('token', accessToken);
+    localStorage.setItem('user', JSON.stringify(userInfo));
+  }
+};

--- a/src/utils/loginHandler.ts
+++ b/src/utils/loginHandler.ts
@@ -5,10 +5,7 @@ export const handleLoginSuccess = (accessToken: string | null) => {
     const payload = accessToken.split('.')[1] || '';
     const decodedPayload = decode(payload);
     const payloadObject = JSON.parse(decodedPayload);
-
-    const tokenRole = payloadObject.role;
-    const tokenName = payloadObject.name;
-    const tokenId = payloadObject.sub;
+    const { role: tokenRole, name: tokenName, sub: tokenId } = payloadObject;
 
     const userInfo = { name: tokenName, id: tokenId, role: tokenRole };
 


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

## 📌 관련 이슈번호

<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

- Closes #75 

## 🎟️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 리팩토링

## Check List

- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [x] 🏗️ yarn build는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요? (TODO, 주석, clg... etc.)
- [x] ✅ 컨벤션을 지켰나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요?

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 어드민 로그인 페이지를 아래 사진처럼 구현했습니다.
2. callback 페이지에서의 JWT 디코딩 후 localStorage에 저장하는 로직이 관리자 로그인에서도 필요해서 공통으로 뺐어요!
3. 어드민 데스크탑은 따로 메인페이지가 없어서 로그인에 성공하면 일단 대여 내역 관리 페이지로 바로 이동하도록 해놓았습니다.

## 📢 To Reviewers

- useState가 상태가 바뀔 때마다 뷰를 다시 그린다고 알고 있어서 useRef를 사용했는데 프론트 지식이 많이 없어서 맞는지는 잘 모르겠네요.

## 📸 스크린샷
<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->

![image](https://github.com/user-attachments/assets/f584e2cc-c525-4584-ab68-4a2e32c82a05)


## 🔗 참고 자료

<!-- 참고 레퍼런스를 첨부해주세요.  -->
