### PR TITLE
[Feat/#80] 데스크탑 API 페이지네이션 연결

### DIFF
--- a/src/app/desktop/admin-inquiry/_components/AdminTable/index.tsx
+++ b/src/app/desktop/admin-inquiry/_components/AdminTable/index.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import {
   Table,
   TableBody,
@@ -11,6 +10,7 @@ import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { ChevronLeftIcon, ChevronRightIcon } from 'lucide-react';
 import { Admins, TableComponentProps } from '@/types/admins';
+import { PageChangeAction } from '@/types/paginationType';
 
 export default function AdminTable({
   admins,
@@ -18,10 +18,12 @@ export default function AdminTable({
   headers = ['이름', '학번'], // 기본값을 설정
   selected,
   setSelected,
+  currentPage = 1,
+  totalPage = 1,
+  onPageChange = (pageAction: PageChangeAction) => {
+    console.log(pageAction);
+  },
 }: TableComponentProps) {
-  const [currentPage, setCurrentPage] = useState(1);
-  const rowsPerPage = 10;
-
   const handleSelect = (payerId: number) => {
     setSelected((prev: number[]) =>
       prev.includes(payerId)
@@ -30,13 +32,20 @@ export default function AdminTable({
     );
   };
 
+  const handlePageChangeBtnClick = (
+    event: React.MouseEvent<HTMLElement, MouseEvent>,
+    pageChangeAction: PageChangeAction,
+  ) => {
+    event.preventDefault();
+    onPageChange(pageChangeAction);
+  };
   // payers가 배열이 아닐 경우 기본 빈 배열로 대체
-  const paginatedData = Array.isArray(admins)
-    ? admins.slice((currentPage - 1) * rowsPerPage, currentPage * rowsPerPage)
-    : [];
+  // const  = Array.isArray(admins)
+  //   ? admins.slice((currentPage - 1) * rowsPerPage, currentPage * rowsPerPage)
+  //   : [];
 
   const handleSelectAll = () => {
-    const visibleIds = paginatedData.map(
+    const visibleIds = admins.map(
       (item: { memberId: number }) => item.memberId,
     );
     setSelected(
@@ -52,7 +61,7 @@ export default function AdminTable({
             {showCheckboxes && (
               <TableHead className="w-10 text-center">
                 <Checkbox
-                  checked={selected.length === paginatedData.length}
+                  checked={selected.length === admins.length}
                   onCheckedChange={handleSelectAll}
                 />
               </TableHead>
@@ -65,7 +74,7 @@ export default function AdminTable({
           </TableRow>
         </TableHeader>
         <TableBody>
-          {paginatedData.map((item: Admins) => (
+          {admins.map((item: Admins) => (
             <TableRow key={item.memberId}>
               {showCheckboxes && (
                 <TableCell className="w-10 text-center">
@@ -87,18 +96,18 @@ export default function AdminTable({
         <Button
           className="bg-transparent shadow-transparent hover:bg-transparent"
           disabled={currentPage === 1}
-          onClick={() => setCurrentPage((prev) => prev - 1)}
+          onClick={(event) => handlePageChangeBtnClick(event, 'PREV')}
         >
           <ChevronLeftIcon className="h-10 w-10 cursor-pointer text-black-primary" />
         </Button>
         <span>
-          {currentPage} / {Math.ceil(admins.length / rowsPerPage)}
+          {currentPage} / {totalPage}
         </span>
         <Button
           className="bg-transparent shadow-transparent hover:bg-transparent"
           size="chevron"
-          disabled={currentPage === Math.ceil(admins.length / rowsPerPage)}
-          onClick={() => setCurrentPage((prev) => prev + 1)}
+          disabled={currentPage === totalPage}
+          onClick={(event) => handlePageChangeBtnClick(event, 'NEXT')}
         >
           <ChevronRightIcon className="h-6 w-6 cursor-pointer text-black-primary" />
         </Button>

--- a/src/app/desktop/item-list/_components/ItemTable/index.tsx
+++ b/src/app/desktop/item-list/_components/ItemTable/index.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { ChevronLeftIcon, ChevronRightIcon } from 'lucide-react';
 import {
   Table,
@@ -12,6 +11,7 @@ import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Item, ItemTableProps } from '@/types/items';
 import Image from 'next/image';
+import { PageChangeAction } from '@/types/paginationType';
 
 export default function ItemTable({
   items = [],
@@ -19,27 +19,31 @@ export default function ItemTable({
   headers = ['로고', '물품명', '소모품', '총 수량', '대여 중'],
   selected,
   setSelected,
+  currentPage = 1,
+  totalPage = 1,
+  onPageChange = (pageAction: PageChangeAction) => {
+    console.log(pageAction);
+  },
 }: ItemTableProps) {
-  const [currentPage, setCurrentPage] = useState(1);
-  const rowsPerPage = 10;
-
-  const totalPages = Math.ceil((items?.length || 0) / rowsPerPage);
-
   // 선택된 항목을 다루는 함수
   const handleSelect = (id: number) => {
     setSelected(id); // 단일 선택으로 변경
   };
 
-  const paginatedData = items
-    ? items.slice((currentPage - 1) * rowsPerPage, currentPage * rowsPerPage)
-    : [];
-
   const handleSelectAll = () => {
-    if (selected === paginatedData[0]?.itemId) {
+    if (selected === items[0]?.itemId) {
       setSelected(0); // 전체 선택 해제
     } else {
-      setSelected(paginatedData[0]?.itemId); // 첫 번째 항목을 선택(전체 선택)
+      setSelected(items[0]?.itemId); // 첫 번째 항목을 선택(전체 선택)
     }
+  };
+
+  const handlePageChangeBtnClick = (
+    event: React.MouseEvent<HTMLElement, MouseEvent>,
+    pageChangeAction: PageChangeAction,
+  ) => {
+    event.preventDefault();
+    onPageChange(pageChangeAction);
   };
 
   return (
@@ -50,7 +54,7 @@ export default function ItemTable({
             {showCheckboxes && (
               <TableHead className="w-10 text-center">
                 <Checkbox
-                  checked={selected === paginatedData[0]?.itemId} // 선택된 첫 번째 항목이 전체 항목과 일치하는지 확인
+                  checked={selected === items[0]?.itemId} // 선택된 첫 번째 항목이 전체 항목과 일치하는지 확인
                   onCheckedChange={handleSelectAll}
                 />
               </TableHead>
@@ -63,9 +67,9 @@ export default function ItemTable({
           </TableRow>
         </TableHeader>
         <TableBody>
-          {paginatedData.length > 0 ? (
-            paginatedData.map((item: Item) => (
-              <TableRow key={item.itemId}>
+          {items.length > 0 ? (
+            items.map((item: Item) => (
+              <TableRow key={`${item.itemId}${item.itemName}`}>
                 {showCheckboxes && (
                   <TableCell className="w-10 text-center">
                     <Checkbox
@@ -111,18 +115,18 @@ export default function ItemTable({
         <div className="flex items-center gap-2">
           <Button
             className="bg-transparent shadow-transparent hover:bg-transparent"
-            disabled={currentPage === 1 || totalPages === 0}
-            onClick={() => setCurrentPage((prev) => prev - 1)}
+            disabled={currentPage === 1}
+            onClick={(event) => handlePageChangeBtnClick(event, 'PREV')}
           >
             <ChevronLeftIcon className="h-10 w-10 cursor-pointer text-black-primary" />
           </Button>
           <span>
-            {totalPages > 0 ? `${currentPage} / ${totalPages}` : '0 / 0'}
+            {currentPage} / {totalPage}
           </span>
           <Button
             className="bg-transparent shadow-transparent hover:bg-transparent"
-            disabled={currentPage === totalPages || totalPages === 0}
-            onClick={() => setCurrentPage((prev) => prev + 1)}
+            disabled={currentPage === totalPage}
+            onClick={(event) => handlePageChangeBtnClick(event, 'NEXT')}
           >
             <ChevronRightIcon className="h-6 w-6 cursor-pointer text-black-primary" />
           </Button>

--- a/src/app/desktop/payer-inquiry/_components/TableComponent/index.tsx
+++ b/src/app/desktop/payer-inquiry/_components/TableComponent/index.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import {
   Table,
   TableBody,
@@ -11,6 +10,7 @@ import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { ChevronLeftIcon, ChevronRightIcon } from 'lucide-react';
 import { Payer, TableComponentProps } from '@/types/payers';
+import { PageChangeAction } from '@/types/paginationType';
 
 export default function TableComponent({
   payers,
@@ -18,10 +18,12 @@ export default function TableComponent({
   headers = ['이름', '학번', '회원 여부'], // 기본값을 설정
   selected,
   setSelected,
+  currentPage = 1,
+  totalPage = 1,
+  onPageChange = (pageChangeAction: PageChangeAction) => {
+    console.log(pageChangeAction);
+  },
 }: TableComponentProps) {
-  const [currentPage, setCurrentPage] = useState(1);
-  const rowsPerPage = 10;
-
   const handleSelect = (payerId: number) => {
     setSelected((prev: number[]) =>
       prev.includes(payerId)
@@ -30,18 +32,19 @@ export default function TableComponent({
     );
   };
 
-  // payers가 배열이 아닐 경우 기본 빈 배열로 대체
-  const paginatedData = Array.isArray(payers)
-    ? payers.slice((currentPage - 1) * rowsPerPage, currentPage * rowsPerPage)
-    : [];
-
   const handleSelectAll = () => {
-    const visibleIds = paginatedData.map(
-      (item: { payerId: number }) => item.payerId,
-    );
+    const visibleIds = payers.map((item: { payerId: number }) => item.payerId);
     setSelected(
       (prev: number[]) => (prev.length === visibleIds.length ? [] : visibleIds), // 배열 길이를 비교하는 대신 선택된 아이디와 비교
     );
+  };
+
+  const handlePageChangeBtnClick = (
+    event: React.MouseEvent<HTMLElement, MouseEvent>,
+    pageChangeAction: PageChangeAction,
+  ) => {
+    event.preventDefault();
+    onPageChange(pageChangeAction);
   };
 
   return (
@@ -52,7 +55,7 @@ export default function TableComponent({
             {showCheckboxes && (
               <TableHead className="w-10 text-center">
                 <Checkbox
-                  checked={selected.length === paginatedData.length}
+                  checked={selected.length === payers.length}
                   onCheckedChange={handleSelectAll}
                 />
               </TableHead>
@@ -65,8 +68,8 @@ export default function TableComponent({
           </TableRow>
         </TableHeader>
         <TableBody>
-          {paginatedData.map((item: Payer) => (
-            <TableRow key={item.payerId}>
+          {payers.map((item: Payer) => (
+            <TableRow key={`${item.payerId}${item.studentId}`}>
               {showCheckboxes && (
                 <TableCell className="w-10 text-center">
                   <Checkbox
@@ -90,18 +93,18 @@ export default function TableComponent({
         <Button
           className="bg-transparent shadow-transparent hover:bg-transparent"
           disabled={currentPage === 1}
-          onClick={() => setCurrentPage((prev) => prev - 1)}
+          onClick={(event) => handlePageChangeBtnClick(event, 'PREV')}
         >
           <ChevronLeftIcon className="h-10 w-10 cursor-pointer text-black-primary" />
         </Button>
         <span>
-          {currentPage} / {Math.ceil(payers.length / rowsPerPage)}
+          {currentPage} / {totalPage}
         </span>
         <Button
           className="bg-transparent shadow-transparent hover:bg-transparent"
           size="chevron"
-          disabled={currentPage === Math.ceil(payers.length / rowsPerPage)}
-          onClick={() => setCurrentPage((prev) => prev + 1)}
+          disabled={currentPage === totalPage}
+          onClick={(event) => handlePageChangeBtnClick(event, 'NEXT')}
         >
           <ChevronRightIcon className="h-6 w-6 cursor-pointer text-black-primary" />
         </Button>

--- a/src/app/desktop/rental-history/_components/RentalsTable/index.tsx
+++ b/src/app/desktop/rental-history/_components/RentalsTable/index.tsx
@@ -10,6 +10,7 @@ import {
 import { Button } from '@/components/ui/button';
 import { RentalsTableProps } from '@/types/rentals';
 import { PageChangeAction } from '@/types/paginationType';
+import StatusBadge from '@/app/mobile/history/_components/StatusBadge';
 
 export default function RentalsTable({
   rentalHistories,
@@ -69,7 +70,9 @@ export default function RentalsTable({
                   {rental.itemName}
                 </TableCell>
                 <TableCell className="w-30 text-center">
-                  {rental.rentalStatus}
+                  <div className="flex items-center justify-center">
+                    <StatusBadge status={rental.rentalStatus} />
+                  </div>
                 </TableCell>
               </TableRow>
             ))

--- a/src/app/desktop/rental-history/_components/RentalsTable/index.tsx
+++ b/src/app/desktop/rental-history/_components/RentalsTable/index.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { ChevronLeftIcon, ChevronRightIcon } from 'lucide-react';
 import {
   Table,
@@ -10,6 +9,7 @@ import {
 } from '@/components/ui/table';
 import { Button } from '@/components/ui/button';
 import { RentalsTableProps } from '@/types/rentals';
+import { PageChangeAction } from '@/types/paginationType';
 
 export default function RentalsTable({
   rentalHistories,
@@ -21,16 +21,19 @@ export default function RentalsTable({
     '대여 물품',
     '물품 상태',
   ],
+  currentPage = 1,
+  totalPage = 1,
+  onPageChange = (pageChangeAction: PageChangeAction) => {
+    console.log(pageChangeAction);
+  },
 }: RentalsTableProps) {
-  const [currentPage, setCurrentPage] = useState(1);
-  const rowsPerPage = 10;
-
-  const totalPages = Math.ceil(rentalHistories.length / rowsPerPage);
-
-  const paginatedData = rentalHistories.slice(
-    (currentPage - 1) * rowsPerPage,
-    currentPage * rowsPerPage,
-  );
+  const handlePageChangeBtnClick = (
+    event: React.MouseEvent<HTMLElement, MouseEvent>,
+    pageChangeAction: PageChangeAction,
+  ) => {
+    event.preventDefault();
+    onPageChange(pageChangeAction);
+  };
 
   return (
     <div className="flex w-full flex-col p-10">
@@ -45,8 +48,8 @@ export default function RentalsTable({
           </TableRow>
         </TableHeader>
         <TableBody>
-          {paginatedData.length > 0 ? (
-            paginatedData.map((rental) => (
+          {rentalHistories.length > 0 ? (
+            rentalHistories.map((rental) => (
               <TableRow key={rental.rentalHistoryId}>
                 <TableCell className="w-30 text-center">
                   {rental.member.name}
@@ -81,18 +84,18 @@ export default function RentalsTable({
         <div className="flex items-center gap-2">
           <Button
             className="bg-transparent shadow-transparent hover:bg-transparent"
-            disabled={currentPage === 1 || totalPages === 0}
-            onClick={() => setCurrentPage((prev) => prev - 1)}
+            disabled={currentPage === 1}
+            onClick={(event) => handlePageChangeBtnClick(event, 'PREV')}
           >
             <ChevronLeftIcon className="h-10 w-10 cursor-pointer text-black-primary" />
           </Button>
           <span>
-            {totalPages > 0 ? `${currentPage} / ${totalPages}` : '0 / 0'}
+            {currentPage} / {totalPage}
           </span>
           <Button
             className="bg-transparent shadow-transparent hover:bg-transparent"
-            disabled={currentPage === totalPages || totalPages === 0}
-            onClick={() => setCurrentPage((prev) => prev + 1)}
+            disabled={currentPage === totalPage}
+            onClick={(event) => handlePageChangeBtnClick(event, 'NEXT')}
           >
             <ChevronRightIcon className="h-6 w-6 cursor-pointer text-black-primary" />
           </Button>

--- a/src/app/desktop/rental-history/page.tsx
+++ b/src/app/desktop/rental-history/page.tsx
@@ -3,13 +3,29 @@
 import { useQuery } from '@tanstack/react-query';
 
 import { getRentals } from '@/services/rentals';
+import { useEffect, useState } from 'react';
+import { PageChangeAction } from '@/types/paginationType';
 import RentalsTable from './_components/RentalsTable';
 
 export default function RentalHistoryPage() {
-  const { data: originalData = [] } = useQuery({
+  const [page, setPage] = useState(1);
+
+  const { data: originalData = [], refetch } = useQuery({
     queryKey: ['rentals'],
-    queryFn: getRentals,
+    queryFn: () => getRentals(page - 1),
   });
+
+  useEffect(() => {
+    refetch();
+  }, [page]);
+
+  const handlePageChange = async (pageChangeAction: PageChangeAction) => {
+    console.log('PageChange:', pageChangeAction);
+    setPage((current) =>
+      pageChangeAction === 'NEXT' ? current + 1 : current - 1,
+    );
+    console.log(`page: ${page}`);
+  };
 
   return (
     <div className="flex flex-col justify-center gap-8 px-4 md:px-16 lg:px-64">
@@ -18,7 +34,12 @@ export default function RentalHistoryPage() {
       </div>
 
       <div className="flex flex-col justify-between">
-        <RentalsTable rentalHistories={originalData.rentalHistories || []} />
+        <RentalsTable
+          rentalHistories={originalData.rentalHistories || []}
+          currentPage={page}
+          totalPage={originalData.totalPage}
+          onPageChange={handlePageChange}
+        />
       </div>
     </div>
   );

--- a/src/services/admins.ts
+++ b/src/services/admins.ts
@@ -1,9 +1,12 @@
 import PublicAxiosInstance from '@/services/publicAxiosInstance';
 import PrivateAxiosInstance from './privateAxiosInstance';
 
-export const getAdmins = async (searchQuery?: string) => {
+export const getAdmins = async (searchQuery?: string, page?: number) => {
   const response = await PrivateAxiosInstance.get('/admin/members/admins', {
-    params: searchQuery ? { search: searchQuery } : searchQuery,
+    params: {
+      pageNo: page || 0,
+      search: searchQuery || '',
+    },
   });
   return response.data;
 };

--- a/src/services/items.ts
+++ b/src/services/items.ts
@@ -1,8 +1,11 @@
 import PrivateAxiosInstance from './privateAxiosInstance';
 
-export const getItems = async (searchQuery?: string) => {
+export const getItems = async (searchQuery?: string, page?: number) => {
   const response = await PrivateAxiosInstance.get('/admin/items', {
-    params: searchQuery ? { search: searchQuery } : {},
+    params: {
+      pageNo: page || 0,
+      search: searchQuery || '',
+    },
   });
   return response.data;
 };

--- a/src/services/payers.ts
+++ b/src/services/payers.ts
@@ -1,8 +1,11 @@
 import PrivateAxiosInstance from './privateAxiosInstance';
 
-export const getPayer = async (searchQuery?: string) => {
+export const getPayer = async (searchQuery?: string, page?: number) => {
   const response = await PrivateAxiosInstance.get('/admin/members/payers', {
-    params: searchQuery ? { search: searchQuery } : {},
+    params: {
+      pageNo: page || 0,
+      search: searchQuery || '',
+    },
   });
   return response.data;
 };

--- a/src/services/rentals.ts
+++ b/src/services/rentals.ts
@@ -1,7 +1,11 @@
 import PrivateAxiosInstance from './privateAxiosInstance';
 
 // eslint-disable-next-line import/prefer-default-export
-export const getRentals = async () => {
-  const response = await PrivateAxiosInstance.get('/admin/rentals');
+export const getRentals = async (page?: number) => {
+  const response = await PrivateAxiosInstance.get('/admin/rentals', {
+    params: {
+      pageNo: page || 0,
+    },
+  });
   return response.data;
 };

--- a/src/types/admins.ts
+++ b/src/types/admins.ts
@@ -1,10 +1,12 @@
+import { PaginationProps } from '@/types/paginationType';
+
 export interface Admins {
   memberId: number;
   name: string;
   studentId: string;
 }
 
-export interface TableComponentProps {
+export interface TableComponentProps extends PaginationProps {
   admins: Admins[];
   showCheckboxes?: boolean;
   headers?: string[];

--- a/src/types/items.ts
+++ b/src/types/items.ts
@@ -1,3 +1,5 @@
+import { PaginationProps } from '@/types/paginationType';
+
 export interface Item {
   itemId: number;
   itemName: string;
@@ -7,7 +9,7 @@ export interface Item {
   imageUrl: string;
 }
 
-export interface ItemTableProps {
+export interface ItemTableProps extends PaginationProps {
   items: Item[];
   showCheckboxes?: boolean;
   headers?: string[];

--- a/src/types/paginationType.ts
+++ b/src/types/paginationType.ts
@@ -1,0 +1,7 @@
+export interface PaginationProps {
+  currentPage?: number;
+  totalPage?: number;
+  onPageChange?: (pageAction: PageChangeAction) => void;
+}
+
+export type PageChangeAction = 'PREV' | 'NEXT';

--- a/src/types/payers.ts
+++ b/src/types/payers.ts
@@ -1,3 +1,5 @@
+import { PaginationProps } from '@/types/paginationType';
+
 export interface Payer {
   payerId: number;
   name: string;
@@ -5,7 +7,7 @@ export interface Payer {
   registered: boolean;
 }
 
-export interface TableComponentProps {
+export interface TableComponentProps extends PaginationProps {
   payers: Payer[];
   showCheckboxes?: boolean;
   headers?: string[];

--- a/src/types/rentals.ts
+++ b/src/types/rentals.ts
@@ -1,3 +1,5 @@
+import { PaginationProps } from '@/types/paginationType';
+
 export interface Member {
   name: string;
   studentId: string;
@@ -13,7 +15,7 @@ export interface Rentals {
   count?: number; // 물품 수량 (필요시 추가)
 }
 
-export interface RentalsTableProps {
+export interface RentalsTableProps extends PaginationProps {
   rentalHistories: Rentals[];
   headers?: string[];
 }


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

## 📌 관련 이슈번호

<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

- Closes #80 

## 🎟️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 리팩토링

## Check List

- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [x] 🏗️ yarn build는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요? (TODO, 주석, clg... etc.)
- [x] ✅ 컨벤션을 지켰나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요?

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 데스크탑에서 납부자, 관리자, 물품, 대여기록을 조회할 때 페이지별로 조회하도록 구현하였습니다.
2. 총 페이지 수가 넘어가도 다음 페이지가 넘어가던 현상을 수정하였습니다.

## 📢 To Reviewers

- 데이터를 조회하는 부분이 페이지 단에 있어서 현재 페이지 상태관리를 테이블 컴포넌트 단에서 페이지 단으로 뺐습니다. 4개 페이지 전부 같은 구조라 일단 복붙으로 붙여놓긴 했는데 이정도는 그냥 냅두고 나중에 데스크탑 구조 전체를 좀 뜯어고쳐야 할 거 같아요.

+ 추가!
대여 내역 조회에서 대여 상태를 모바일에서 보여주는 것처럼 배지로 표시하게 했는데 상태 배지 컴포넌트를 공통 컴포넌트로 빼야할 것 같습니다!

## 📸 스크린샷

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->

## 🔗 참고 자료

<!-- 참고 레퍼런스를 첨부해주세요.  -->
