### PR TITLE
[Fix/#118] 바텀시트 수량/시간 input 클릭 시 확대되는 버그 수정

### DIFF
--- a/src/components/mobile/BottomSheet/index.tsx
+++ b/src/components/mobile/BottomSheet/index.tsx
@@ -275,7 +275,7 @@ export default function BottomSheet({
               </div>
               <input
                 type="number"
-                className={`rounded-[10px] border px-3.5 py-2.5 text-caption-1_midi font-medium ${
+                className={`rounded-[10px] border px-3.5 py-2.5 text-base font-medium ${
                   errors.quantity ? 'border-warning' : 'border-gray-border'
                 }`}
                 placeholder="0"
@@ -294,7 +294,7 @@ export default function BottomSheet({
               <div className="text-body-2-normal_semi font-semibold text-black-primary">
                 시간
               </div>
-              <div className="flex items-center gap-2 text-caption-1_midi font-medium">
+              <div className="flex items-center gap-2 text-base font-medium">
                 <input
                   type="number"
                   className={`w-1/2 rounded-[10px] border px-3.5 py-2.5 ${


### PR DESCRIPTION
## 📌 관련 이슈번호

- Closes #118 

## 🎟️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 리팩토링

## Check List

- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [x] 🏗️ yarn build는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요? (TODO, 주석, clg... etc.)
- [x] ✅ 컨벤션을 지켰나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요?

## ✅ Key Changes

1. 바텀 시트 수량 폰트 사이즈 16px
2. 바텀 시트 시간 폰트 사이즈 16px

## 📢 To Reviewers

- 아무리 생각해도 모달 내에 인풋 클릭하면 확대되는 게 너무 불편한 것 같아서 급하게 수정했습니다... 16px 안 에뻐서 걱정했는데 수민 오빠랑 테스트 해보니까 괜찮은 것 같아서 진행했어요!
- 원래 검색바도 16px 이상으로 키우려고 했는데 키우면 좌측 제목보다 검색바가 커져서 너무 안 예뻐서... 지금 물품이 많이 없어서 검색은 비교적 덜 사용하니까 어떻게 하면 좋을지 생각해보면 좋을 것 같아요!