### PR TITLE
[Feat/#135] 사용자 알림 모두 읽음으로 표시 버튼 생성

### DIFF
--- a/src/app/mobile/admin/notification/page.tsx
+++ b/src/app/mobile/admin/notification/page.tsx
@@ -8,7 +8,7 @@ import { elapsedTime } from '@/utils/elapsedTime';
 import { NotificationProps } from '@/types/notificationType';
 import {
   adminNotificationGet,
-  readNotificationPost,
+  readNotificationPatch,
 } from '@/services/notification';
 
 type AdminNotificationType = NotificationProps;
@@ -28,7 +28,7 @@ export default function Notification() {
   }, []);
 
   const handleReadNotification = async (notificationId: number) => {
-    await readNotificationPost(notificationId);
+    await readNotificationPatch(notificationId);
   };
 
   return (

--- a/src/app/mobile/notification/page.tsx
+++ b/src/app/mobile/notification/page.tsx
@@ -5,7 +5,8 @@ import { useRouter } from 'next/navigation';
 import MobileLayout from '@/components/mobile/layout';
 import {
   userNotificationGet,
-  readNotificationPost,
+  readNotificationPatch,
+  readNotificationAllPatch,
 } from '@/services/notification';
 import NotificationItem from '@/components/mobile/NotificationItem';
 import Header from '@/components/mobile/Header';
@@ -39,10 +40,13 @@ export default function Notification() {
     fetchNotifications();
   }, []);
 
-  // TODO : 로그인 여부 확인 후 로그인 안 했으면 로그인 화면으로 보내기
-
   const handleReadNotification = async (notificationId: number) => {
-    await readNotificationPost(notificationId);
+    await readNotificationPatch(notificationId);
+  };
+
+  const handleClickAllNotification = async () => {
+    await readNotificationAllPatch();
+    window.location.reload();
   };
 
   return (
@@ -53,19 +57,32 @@ export default function Notification() {
           현재 알림이 없습니다.
         </div>
       ) : (
-        notificationDetail.map((item) => (
-          <NotificationItem
-            key={item.notificationId}
-            message={item.message}
-            link={item.link}
-            isRead={item.isRead}
-            status={item.status}
-            createdAt={elapsedTime(item.createdAt)}
-            handleNotification={() =>
-              item.notificationId && handleReadNotification(item.notificationId)
-            }
-          />
-        ))
+        <div className="flex flex-col">
+          <div className="flex justify-end px-4 py-1">
+            <button
+              type="button"
+              onClick={handleClickAllNotification}
+              className="text-xs font-medium text-gray-secondary"
+            >
+              모두 읽음으로 표시
+            </button>
+          </div>
+
+          {notificationDetail.map((item) => (
+            <NotificationItem
+              key={item.notificationId}
+              message={item.message}
+              link={item.link}
+              isRead={item.isRead}
+              status={item.status}
+              createdAt={elapsedTime(item.createdAt)}
+              handleNotification={() =>
+                item.notificationId &&
+                handleReadNotification(item.notificationId)
+              }
+            />
+          ))}
+        </div>
       )}
     </MobileLayout>
   );

--- a/src/services/notification.ts
+++ b/src/services/notification.ts
@@ -18,7 +18,7 @@ const adminNotificationGet = async () => {
   }
 };
 
-const readNotificationPost = async (notificationId: number) => {
+const readNotificationPatch = async (notificationId: number) => {
   try {
     const response = await PrivateAxiosInstance.patch(
       `notifications/${notificationId}`,
@@ -29,4 +29,18 @@ const readNotificationPost = async (notificationId: number) => {
   }
 };
 
-export { adminNotificationGet, userNotificationGet, readNotificationPost };
+const readNotificationAllPatch = async () => {
+  try {
+    const response = await PrivateAxiosInstance.patch('notifications/all');
+    return response.data;
+  } catch (error) {
+    return [];
+  }
+};
+
+export {
+  adminNotificationGet,
+  readNotificationAllPatch,
+  readNotificationPatch,
+  userNotificationGet,
+};


### PR DESCRIPTION
## 📌 관련 이슈번호

- Closes #135 

## 🎟️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 리팩토링

## Check List

- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [x] 🏗️ yarn build는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요? (TODO, 주석, clg... etc.)
- [x] ✅ 컨벤션을 지켰나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요?

## ✅ Key Changes

알림 페이지에 모든 알림을 한 번에 읽음 처리하는 `모두 읽음으로 표시` 버튼을 추가하였습니다.

## 📢 To Reviewers

- 특이사항 없습니다~! 잘 돌아가는 거 확인했고 API는 일반 알림 읽음 표시하듯이 처리했습니다

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/86f1ac30-7031-488d-8012-00f92941eeb7)

